### PR TITLE
Branches preview

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,14 @@ language: node_js
 node_js:
   - "node"
 deploy:
-  skip_cleanup: true
-  provider: script
-  script: npm run deploy
-  on:
-    branch: master
+  - skip_cleanup: true
+    provider: script
+    script: npm run deploy
+    on:
+      branch: master
+  - skip_cleanup: true
+    provider: script
+    script: npm run deploy-branch
+    on:
+      all_branches: true
+      condition: '"$TRAVIS_BRANCH" != "master" && "$TRAVIS_BRANCH" != "gh-pages"'

--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -11,6 +11,7 @@
     "packageName": "rebilly-openapi-spec",
     "specVersion": "0.0.1",
     "samples": true,
-    "installSwaggerUI": true
+    "installSwaggerUI": true,
+    "branchPreview": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
     + JSON [http://localhost:3000/swagger-ui/?url=http://localhost:3000/swagger.json](http://localhost:3000/?url=http://localhost:3000/swagger.json)
     + YAML [http://localhost:3000/swagger-ui/?url=http://localhost:3000/swagger.yaml](http://localhost:3000/?url=http://localhost:3000/swagger.yaml)  (may not be fully functional)
 - Browse ReDoc: [http://localhost:3000/](http://localhost:3000/)
+- Preview spec version for branch `<branch>` (**doesn't work locally**): [http://Rebilly.github.io/SwaggerTemplateRepo/preview/&lt;branch&gt;](http://Rebilly.github.io/SwaggerTemplateRepo/preview/branch)
+**!** Branch preview is not available until Travis CI deploys it
 - Import spec by URL in editor, online or local (you should uncheck "Use CORS proxy" in the model)
 
 ## Tests

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "bower": "^1.7.7",
     "cors": "^2.7.1",
-    "deploy-to-gh-pages": "^1.0.0",
+    "deploy-to-gh-pages": "^1.1.0",
     "gulp": "^3.9.1",
     "gulp-connect": "^3.2.0",
     "portfinder": "^1.0.3",
@@ -14,10 +14,11 @@
   },
   "private": true,
   "scripts": {
-    "deploy": "npm run build && deploy-to-gh-pages web_deploy",
+    "deploy": "npm run build && deploy-to-gh-pages --update web_deploy",
     "build": "node ./scripts/build.js",
     "swagger": "swagger-repo",
     "test": "swagger-repo validate",
-    "start": "gulp serve"
+    "start": "gulp serve",
+    "deploy-branch": "node ./scripts/deploy-branch"
   }
 }

--- a/scripts/deploy-branch.js
+++ b/scripts/deploy-branch.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+'use strict';
+require('shelljs/global');
+var path = require('path');
+
+set('-e');
+set('-v');
+
+var branch = process.env.TRAVIS_BRANCH && process.env.TRAVIS_BRANCH.toLowerCase();
+if (branch && branch !== 'gh-pages') {
+  var branchPath = path.join('.tmp', 'preview', branch, '/');
+  mkdir('-p', branchPath);
+  exec('npm run swagger bundle -- -o ' + branchPath + 'swagger.json');
+  cp('web/index.html', branchPath);
+  exec('deploy-to-gh-pages --update .tmp');
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>REST API Specification</title>
+    <title>Rebilly REST API Specification</title>
     <!-- needed for adaptive design -->
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
Adding possibility to preview spec version from any specific branch as suggested by @slavcodev 

Details:
- to preview specific branch you add the following to the URL: `/preview/<branch-name`, e.g.: [http://rebilly.github.io/RebillyAPI/preview/branches-preview/](http://rebilly.github.io/RebillyAPI/preview/branches-preview/)
- branch gets available for preview after Travis runs on it. Travis won't run deployment on a branch if it doesn't contain appropriate `.travis.yml`. So for old branches, you will not see any previews unless you merge these changes into
- any change made on the branch gets available for preview not immediately but after TravisCI run
- currently, there is no mechanism to clean up old branches. I will either clean up them manually from times to times or set up handler of GitHub hook

Why I didn't use just query param to specify branch (e.g. `?preview=<branch-name>`):
- it requires routing code in the production (master) version
- it is not so flexible: with current approach we are able to have different versions of ReDoc on different previews