### PR TITLE
Revert "Change Scheduling/Methods specifications"

### DIFF
--- a/spec/definitions/Scheduling/Methods/date-interval.yaml
+++ b/spec/definitions/Scheduling/Methods/date-interval.yaml
@@ -7,12 +7,6 @@ allOf:
         minimum: 1
       unit:
         $ref: "#/definitions/TimeUnit"
-      chronology:
-        type: string
-        default: "after"
-        enum:
-          - "after"
-          - "before"
     required:
       - duration
       - unit

--- a/spec/definitions/Scheduling/Methods/day-of-month.yaml
+++ b/spec/definitions/Scheduling/Methods/day-of-month.yaml
@@ -6,12 +6,6 @@ allOf:
         type: integer
         minimum: 1
         maximum: 31
-      chronology:
-        type: string
-        default: "next"
-        enum:
-          - "next"
-          - "previous"
       conflictPolicy:
         description: |
           The strategy how to solve the lack of the numbers of days in a month.

--- a/spec/definitions/Scheduling/Methods/day-of-week.yaml
+++ b/spec/definitions/Scheduling/Methods/day-of-week.yaml
@@ -9,11 +9,8 @@ allOf:
         default: "next"
         enum:
           - "next"
-          - "previous"
-          - "first-in-next-month"
-          - "last-in-next-month"
-          - "first-in-previous-month"
-          - "last-in-previous-month"
+          - "first-in-month"
+          - "last-in-month"
       time:
         $ref: "#/definitions/Time"
     required:


### PR DESCRIPTION
Reverts Rebilly/RebillyAPI#63

After discussion with @vova07, we came to the conclusion that these changes are wrong.

Scheduling methods is a set of values to use in consumer, but only consumer should decide need to add or subtract it from some date.

Even the PHP implementation shows the bad design: code duplicates, too complicated logic on calculation.