### PR TITLE
Rename userName for ApiKeys spec (GWY-4333)

### DIFF
--- a/spec/definitions/ApiKey.yaml
+++ b/spec/definitions/ApiKey.yaml
@@ -15,7 +15,7 @@ properties:
     enum:
       - mysql
       - iso8601
-  userName:
+  apiName:
     description: API user name
     type: string
     readOnly: true

--- a/spec/definitions/ApiKey.yaml
+++ b/spec/definitions/ApiKey.yaml
@@ -15,7 +15,7 @@ properties:
     enum:
       - mysql
       - iso8601
-  apiName:
+  apiUser:
     description: API user name
     type: string
     readOnly: true


### PR DESCRIPTION
There was a suggestion in GWY-4333, to rename userName to something more semantically related to the resource.