### PR TITLE
Change tags for Histogram endpoint

### DIFF
--- a/spec/paths/histograms@transactions.yaml
+++ b/spec/paths/histograms@transactions.yaml
@@ -1,8 +1,6 @@
 get:
   tags:
-    - Transaction
     - Histogram
-    - Report
   summary: Get Transaction histogram report data
   description: |
     Get Transaction histogram report data.

--- a/spec/paths/histograms@transactions.yaml
+++ b/spec/paths/histograms@transactions.yaml
@@ -1,6 +1,6 @@
 get:
   tags:
-    - Histogram
+    - Histograms
   summary: Get Transaction histogram report data
   description: |
     Get Transaction histogram report data.


### PR DESCRIPTION
Current documentation duplicates Histogram endpoint description under Report and Transaction tags / sections. It was decided to use the term Histogram as the most accurate and get rid of duplicates.