### PR TITLE
Remove evidence from Dispute until it will be implemented on backend

### DIFF
--- a/spec/definitions/Dispute.yaml
+++ b/spec/definitions/Dispute.yaml
@@ -185,13 +185,13 @@ properties:
     description: Dispute raw response from gateway
     type: string
     readOnly: true
-  evidence:
-    allOf:
-      - $ref: "#/definitions/DisputeEvidence"
-  evidenceSubmissionTime:
-    description: Dispute evidence submission time
-    allOf:
-      - $ref: "#/definitions/ServerTimestamp"
+  #evidence:
+  #  allOf:
+  #    - $ref: "#/definitions/DisputeEvidence"
+  #evidenceSubmissionTime:
+  #  description: Dispute evidence submission time
+  #  allOf:
+  #    - $ref: "#/definitions/ServerTimestamp"
   resolvedTime:
     description: Dispute resolved time
     allOf:


### PR DESCRIPTION
We did not implemented Evidence on the backend, so our Dispute response does not match spec. 

I propose to comment those fields until Evidences will be implemented