### PR TITLE
Rename PayR to Payr the correct way to writing

### DIFF
--- a/spec/definitions/GatewayAccountConfig/Payr.yaml
+++ b/spec/definitions/GatewayAccountConfig/Payr.yaml
@@ -1,4 +1,4 @@
-description: PayR Gateway config
+description: Payr Gateway config
 allOf:
   -
     $ref: "#/definitions/GatewayAccount"
@@ -12,10 +12,10 @@ allOf:
         properties:
           clientId:
             type: string
-            description: PayR Gateway client ID
+            description: Payr Gateway client ID
           secretWord:
             type: string
-            description: PayR Gateway secret word
+            description: Payr Gateway secret word
             format: password
         required:
           - "clientId"

--- a/spec/definitions/Gateways/AcquirerName.yaml
+++ b/spec/definitions/Gateways/AcquirerName.yaml
@@ -43,7 +43,7 @@ enum:
   - Other
   - Panda Bank
   - PayPal
-  - PayR
+  - Payr
   - Payvision
   - Peoples Trust Company
   - Privatbank

--- a/spec/definitions/Gateways/GatewayName.yaml
+++ b/spec/definitions/Gateways/GatewayName.yaml
@@ -30,7 +30,7 @@ enum:
  - PandaGateway
  - Payeezy
  - PayPal
- - PayR
+ - Payr
  - Payvision
  - Plugnpay
  - Realex


### PR DESCRIPTION
we are using `Payr `in the backend side, not `PayR `(as here)
as i investigated it in internet, the correct name **Payr**