### PR TITLE
Add Geo Data fields to RiskMetadata

### DIFF
--- a/spec/definitions/RiskMetadata.yaml
+++ b/spec/definitions/RiskMetadata.yaml
@@ -30,12 +30,15 @@ properties:
     readOnly: true
   country:
     description: Country ISO Alpha-2 code for specified ipAddress
+    maxLength: 2
     type: string
     readOnly: true
+    example: "US"
   city:
     description: City for specified ipAddress
     type: string
     readOnly: true
+    example: "New York"
   latitude:
     description: Latitude for specified ipAddress
     type: number
@@ -57,7 +60,7 @@ properties:
     readOnly: true
     example: "America/New_York"
   accuracyRadius:
-    description: Accuracy radius for specified ipAddress
+    description: Accuracy radius for specified ipAddress (kilometers)
     type: integer
     readOnly: true
   fingerprint:

--- a/spec/definitions/RiskMetadata.yaml
+++ b/spec/definitions/RiskMetadata.yaml
@@ -28,6 +28,38 @@ properties:
     description: Internet Service Provider name, if available
     type: string
     readOnly: true
+  country:
+    description: Country ISO Alpha-2 code for specified ipAddress
+    type: string
+    readOnly: true
+  city:
+    description: City for specified ipAddress
+    type: string
+    readOnly: true
+  latitude:
+    description: Latitude for specified ipAddress
+    type: number
+    format: double
+    readOnly: true
+  longitude:
+    description: Longitude for specified ipAddress
+    type: number
+    format: double
+    readOnly: true
+  postalCode:
+    description: Postal code for specified ipAddress
+    type: string
+    maxLength: 10
+    readOnly: true
+  timeZone:
+    description: Time zone for specified ipAddress
+    type: string
+    readOnly: true
+    example: "America/New_York"
+  accuracyRadius:
+    description: Accuracy radius for specified ipAddress
+    type: integer
+    readOnly: true
   fingerprint:
     description: The fingerprint
     type: string


### PR DESCRIPTION
Moved from this PR - https://github.com/Rebilly/RebillyAPI/pull/329, as Geo Data feature was added after the rest RiskMetadata.