### PR TITLE
Remove isOutdated from Contact

### DIFF
--- a/spec/definitions/Contact.yaml
+++ b/spec/definitions/Contact.yaml
@@ -46,10 +46,6 @@ properties:
     $ref: "#/definitions/ContactPhoneNumbers"
   emails:
     $ref: "#/definitions/ContactEmails"
-  isOutdated:
-      description: Is contact outdated
-      type: boolean
-      readOnly: true
   createdTime:
     description: The contact created time
     allOf:


### PR DESCRIPTION
The field `isOutdated` at one time was used by the Rebilly frontend, but is no longer. The data in it is not accurate, so it is being removed.