### PR TITLE
Add new logout endpoint for JWT session clearing

### DIFF
--- a/spec/paths/logout.yaml
+++ b/spec/paths/logout.yaml
@@ -1,0 +1,19 @@
+post:
+  tags:
+    - Users
+    - Sessions
+  summary: Destroys the user's current session
+  description: |
+    Destroys the user's current session. Endpoint must be accessed with valid JWT Authorization header.
+  responses:
+    204:
+      description: Session was deleted
+      headers:
+        Rate-Limit-Limit:
+          $ref: "#/headers/Rate-Limit-Limit"
+        Rate-Limit-Remaining:
+          $ref: "#/headers/Rate-Limit-Remaining"
+        Rate-Limit-Reset:
+          $ref: "#/headers/Rate-Limit-Reset"
+    401:
+      $ref: "#/responses/AccessForbidden"


### PR DESCRIPTION
This endpoint only requires a valid `Authorization` header and will clear the user's current session without requiring any special permissions.