### PR TITLE
Add "approvalWindowTtl" attribute to gateway account

### DIFF
--- a/spec/definitions/GatewayAccount.yaml
+++ b/spec/definitions/GatewayAccount.yaml
@@ -62,6 +62,11 @@ properties:
     type: number
     format: double
     minimum: 0
+  suspendedTransactionLifespan:
+    description: The amount of time (in seconds) a transaction can remain in the SUSPENDED state before it is automatically canceled
+    type: integer
+    minimum: 300
+    maximum: 1296000
   threeDSecure:
     description: True, if Gateway Account allows 3DSecure
     type: boolean

--- a/spec/definitions/GatewayAccount.yaml
+++ b/spec/definitions/GatewayAccount.yaml
@@ -65,6 +65,7 @@ properties:
   suspendedTransactionLifespan:
     description: The amount of time (in seconds) a transaction can remain in the SUSPENDED state before it is automatically canceled
     type: integer
+    default: 3600
     minimum: 300
     maximum: 1296000
   threeDSecure:

--- a/spec/definitions/GatewayAccount.yaml
+++ b/spec/definitions/GatewayAccount.yaml
@@ -62,8 +62,8 @@ properties:
     type: number
     format: double
     minimum: 0
-  suspendedTransactionLifespan:
-    description: The amount of time (in seconds) a transaction can remain in the SUSPENDED state before it is automatically canceled
+  approvalWindowTtl:
+    description: The time window (in seconds) allotted for approving a suspended transaction before it is automatically canceled
     type: integer
     default: 3600
     minimum: 300


### PR DESCRIPTION
New functionality on Gateway Accounts to allow merchants to specify when can a transaction remain suspended until it is canceled automatically by Rebilly.