### PR TITLE
Rename event type payment-declined to transaction-declined

### DIFF
--- a/spec/definitions/EventType.yaml
+++ b/spec/definitions/EventType.yaml
@@ -13,6 +13,6 @@ enum:
   # - subscription-trial-ended
   - payment-card-expired
   - invoice-past-due
-  - payment-declined
+  - transaction-declined
   - transaction-process-requested
   - risk-score-changed

--- a/spec/definitions/GlobalWebhookEventType.yaml
+++ b/spec/definitions/GlobalWebhookEventType.yaml
@@ -8,7 +8,7 @@ enum:
   - subscription-renewed
   - transaction-processed
   - payment-card-expired
-  - payment-declined
+  - transaction-declined
   - invoice-modified
   - invoice-created
   - dispute-created


### PR DESCRIPTION
Rename `payment-declined` event type and global hook event type to `transaction-declined`.