### PR TITLE
Add trial override to Subscriptions

### DIFF
--- a/spec/definitions/Subscription.yaml
+++ b/spec/definitions/Subscription.yaml
@@ -66,7 +66,7 @@ properties:
     readOnly: true
   trial:
     type: object
-    description: Override trial settings. Do not send key to use plan defaults.
+    description: Override trial settings. Send `null` to use plan defaults.
     required:
       - endTime
     properties:

--- a/spec/definitions/Subscription.yaml
+++ b/spec/definitions/Subscription.yaml
@@ -64,6 +64,16 @@ properties:
     description: True if the subscription is currently in a trial period
     type: boolean
     readOnly: true
+  trial:
+    type: object
+    description: Override for trial settings. Set `null` if disabling trial. Do not send key to use plan defaults.
+    required:
+      - endTime
+    properties:
+      endTime:
+        description: The time the trial should end
+        type: string
+        format: date-time
   rebillNumber:
     description: The current period number
     type: integer

--- a/spec/definitions/Subscription.yaml
+++ b/spec/definitions/Subscription.yaml
@@ -66,7 +66,7 @@ properties:
     readOnly: true
   trial:
     type: object
-    description: Override trial settings. Set `null` if disabling trial. Do not send key to use plan defaults.
+    description: Override trial settings. Do not send key to use plan defaults.
     required:
       - endTime
     properties:

--- a/spec/definitions/Subscription.yaml
+++ b/spec/definitions/Subscription.yaml
@@ -66,7 +66,7 @@ properties:
     readOnly: true
   trial:
     type: object
-    description: Override for trial settings. Set `null` if disabling trial. Do not send key to use plan defaults.
+    description: Override trial settings. Set `null` if disabling trial. Do not send key to use plan defaults.
     required:
       - endTime
     properties:

--- a/spec/definitions/Subscription.yaml
+++ b/spec/definitions/Subscription.yaml
@@ -66,7 +66,7 @@ properties:
     readOnly: true
   trial:
     type: object
-    description: Override trial settings. Send `null` to use plan defaults.
+    description: To use plan defaults do not send the `trial` key, or send a `null` value with it.
     required:
       - endTime
     properties:

--- a/spec/definitions/Subscription.yaml
+++ b/spec/definitions/Subscription.yaml
@@ -70,6 +70,9 @@ properties:
     required:
       - endTime
     properties:
+      enabled:
+        description: Enable or disable the trial for this subscription. If enabled for plans without trial prices, the trial will be free.
+        type: boolean
       endTime:
         description: The time the trial should end
         type: string


### PR DESCRIPTION
Document spec changes for overriding trial settings on subscriptions.