### PR TITLE
Add a setting for strings to have a flexible length

### DIFF
--- a/spec/definitions/CustomField.yaml
+++ b/spec/definitions/CustomField.yaml
@@ -38,6 +38,7 @@ properties:
       Parameter Name | Types         | Description
       -------------- | ------------- | -------------
       allowedValues  | string, array | List of allowed values
+      maxLength      | string        | Maximal allowed length for the string, 255 by default, up to 4000
   _links:
     type: array
     description: The links related to resource


### PR DESCRIPTION
I think it's more flexible than a separate type which would differ only by that limit.