### PR TITLE
Add Subscription property orderType

### DIFF
--- a/spec/definitions/Subscription.yaml
+++ b/spec/definitions/Subscription.yaml
@@ -1,16 +1,39 @@
 type: object
+discriminator: "orderType"
 required:
   - customerId
-  - items
   - websiteId
+  - items
 properties:
   id:
     description: The Subscription identifier string
     readOnly: true
     allOf:
       - $ref: "#/definitions/ResourceId"
+  orderType:
+    description: |
+      Specifies the type of order, will the customer receive the order by subscription
+      or is it a one-time purchase
+    type: string
+    enum:
+      - "subscription-order"
+      - "one-time-order"
+    default: "subscription-order"
+  status:
+    description: One-time order status
+    type: string
+    readOnly: true
   customerId:
     description: Unique id for each customer
+    allOf:
+      - $ref: "#/definitions/ResourceId"
+  websiteId:
+    description:  Unique id for each website
+    allOf:
+      - $ref: "#/definitions/ResourceId"
+  initialInvoiceId:
+    description: Unique id for the initial invoice
+    readOnly: true
     allOf:
       - $ref: "#/definitions/ResourceId"
   items:
@@ -28,15 +51,6 @@ properties:
         quantity:
           description: Number of units of the product on the given plan
           type: integer
-  websiteId:
-    description:  Unique id for each website
-    allOf:
-      - $ref: "#/definitions/ResourceId"
-  initialInvoiceId:
-    description: Unique id for the initial invoice
-    readOnly: true
-    allOf:
-      - $ref: "#/definitions/ResourceId"
   deliveryAddress:
     description: Delivery address
     allOf:
@@ -45,82 +59,10 @@ properties:
     description: Billing address
     allOf:
       - $ref: "#/definitions/ContactObject"
-  status:
-    description: Subscription status is deprecated and the values will change to `active`, `canceled`.
-    type: string
-    readOnly: true
-    enum:
-      - Active
-      - Will become active at a future date
-      - Active but set to cancel at next rebill date
-      - Cancelled
-      - Inactive
-      - Suspended
   autopay:
     description: Autopay determines if a payment attempt will be automatic
     type: boolean
     default: true
-  inTrial:
-    description: True if the subscription is currently in a trial period
-    type: boolean
-    readOnly: true
-  trial:
-    type: object
-    description: To use plan defaults do not send the `trial` key, or send a `null` value with it.
-    required:
-      - endTime
-    properties:
-      enabled:
-        description: Enable or disable the trial for this subscription. If enabled for plans without trial prices, the trial will be free.
-        type: boolean
-      endTime:
-        description: The time the trial should end
-        type: string
-        format: date-time
-  rebillNumber:
-    description: The current period number
-    type: integer
-    readOnly: true
-  canceledBy:
-    description: Canceled by
-    type: string
-    readOnly: true
-    enum:
-      - merchant
-      - customer
-      - rebilly
-  cancelCategory:
-    description: Cancel category
-    type: string
-    readOnly: true
-    enum:
-      - billing-failure
-      - did-not-use
-      - did-not-want
-      - missing-features
-      - bugs-or-problems
-      - do-not-remember
-      - risk-warning
-      - contract-expired
-      - too-expensive
-      - never-started
-      - switched-plan
-      - other
-  cancelDescription:
-    description: Cancel reason description in free form
-    type: string
-    readOnly: true
-    maxLength: 255
-  lineItems:
-    description: Subscription line items which queue until the next renewal (or interim) invoice is issued for the subscription.
-    readOnly: true
-    allOf:
-      - $ref: "#/definitions/UpcomingInvoiceItemCollection"
-  lineItemSubtotal:
-    description: Subtotal of line items in this subscription (signed value).  If credits exceed debits, it will be a negative number.
-    readOnly: true
-    type: number
-    example: 49.95
   riskMetadata:
     description: Risk metadata
     allOf:
@@ -133,36 +75,3 @@ properties:
     description: Subscription activation time
     allOf:
       - $ref: "#/definitions/ServerTimestamp"
-  endTime:
-    description: Subscription end time
-    allOf:
-      - $ref: "#/definitions/ServerTimestamp"
-  renewalTime:
-    description: Subscription renewal time
-    type: string
-    format: date-time
-  canceledTime:
-    description: Subscription canceled time
-    allOf:
-      - $ref: "#/definitions/ServerTimestamp"
-  createdTime:
-    description: Subscription created time
-    allOf:
-      - $ref: "#/definitions/ServerTimestamp"
-  updatedTime:
-    description: Subscription updated time
-    allOf:
-      - $ref: "#/definitions/ServerTimestamp"
-  customFields:
-    $ref: "#/definitions/ResourceCustomFields"
-  _links:
-    type: array
-    description: The links related to resource
-    readOnly: true
-    minItems: 1
-    items:
-      - $ref: "#/definitions/SelfLink"
-      - $ref: "#/definitions/CustomerLink"
-      - $ref: "#/definitions/PlanLink"
-      - $ref: "#/definitions/WebsiteLink"
-      - $ref: "#/definitions/LeadSourceLink"

--- a/spec/definitions/Subscription.yaml
+++ b/spec/definitions/Subscription.yaml
@@ -12,8 +12,8 @@ properties:
       - $ref: "#/definitions/ResourceId"
   orderType:
     description: |
-      Specifies the type of order, will the customer receive the order by subscription
-      or is it a one-time purchase
+      Specifies the type of order, a subscription or a one-time purchase.
+      
     type: string
     enum:
       - "subscription-order"

--- a/spec/definitions/Subscription.yaml
+++ b/spec/definitions/Subscription.yaml
@@ -20,7 +20,6 @@ properties:
       - "one-time-order"
     default: "subscription-order"
   status:
-    description: One-time order status
     type: string
     readOnly: true
   customerId:

--- a/spec/definitions/Subscription/OrderTypes/one-time-order.yaml
+++ b/spec/definitions/Subscription/OrderTypes/one-time-order.yaml
@@ -1,0 +1,14 @@
+allOf:
+  - $ref: "#/definitions/Subscription"
+  - properties:
+      status:
+        description: One-time order status
+        type: string
+        readOnly: true
+        enum:
+          - pending
+          - paid
+          - canceled
+  - $ref: "#/definitions/UpcomingInvoice"
+  - $ref: "#/definitions/SubscriptionMetadata"
+  - $ref: "#/definitions/SubscriptionCancellationState"

--- a/spec/definitions/Subscription/OrderTypes/subscription-order.yaml
+++ b/spec/definitions/Subscription/OrderTypes/subscription-order.yaml
@@ -1,0 +1,46 @@
+allOf:
+  - $ref: "#/definitions/Subscription"
+  - properties:
+      status:
+        description: Subscription status is deprecated and the values will change to `active`, `canceled`.
+        type: string
+        readOnly: true
+        enum:
+          - Active
+          - Will become active at a future date
+          - Active but set to cancel at next rebill date
+          - Cancelled
+          - Inactive
+          - Suspended
+      inTrial:
+        description: True if the subscription is currently in a trial period
+        type: boolean
+        readOnly: true
+      trial:
+        type: object
+        description: To use plan defaults do not send the `trial` key, or send a `null` value with it.
+        required:
+          - endTime
+        properties:
+          enabled:
+            description: Enable or disable the trial for this subscription. If enabled for plans without trial prices, the trial will be free.
+            type: boolean
+          endTime:
+            description: The time the trial should end
+            type: string
+            format: date-time
+      endTime:
+        description: Subscription end time
+        allOf:
+          - $ref: "#/definitions/ServerTimestamp"
+      renewalTime:
+        description: Subscription renewal time
+        type: string
+        format: date-time
+      rebillNumber:
+        description: The current period number
+        type: integer
+        readOnly: true
+  - $ref: "#/definitions/UpcomingInvoice"
+  - $ref: "#/definitions/SubscriptionMetadata"
+  - $ref: "#/definitions/SubscriptionCancellationState"

--- a/spec/definitions/Subscription/SubscriptionCancellationState.yaml
+++ b/spec/definitions/Subscription/SubscriptionCancellationState.yaml
@@ -1,0 +1,36 @@
+type: object
+properties:
+  canceledTime:
+    description: Subscription canceled time
+    allOf:
+      - $ref: "#/definitions/ServerTimestamp"
+  canceledBy:
+    description: Canceled by
+    type: string
+    readOnly: true
+    enum:
+      - merchant
+      - customer
+      - rebilly
+  cancelCategory:
+    description: Cancel category
+    type: string
+    readOnly: true
+    enum:
+      - billing-failure
+      - did-not-use
+      - did-not-want
+      - missing-features
+      - bugs-or-problems
+      - do-not-remember
+      - risk-warning
+      - contract-expired
+      - too-expensive
+      - never-started
+      - switched-plan
+      - other
+  cancelDescription:
+    description: Cancel reason description in free form
+    type: string
+    readOnly: true
+    maxLength: 255

--- a/spec/definitions/Subscription/SubscriptionMetadata.yaml
+++ b/spec/definitions/Subscription/SubscriptionMetadata.yaml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  customFields:
+    $ref: "#/definitions/ResourceCustomFields"
+  createdTime:
+    description: Subscription created time
+    allOf:
+      - $ref: "#/definitions/ServerTimestamp"
+  updatedTime:
+    description: Subscription updated time
+    allOf:
+      - $ref: "#/definitions/ServerTimestamp"
+  _links:
+    type: array
+    description: The links related to resource
+    readOnly: true
+    minItems: 1
+    items:
+      - $ref: "#/definitions/SelfLink"
+      - $ref: "#/definitions/CustomerLink"
+      - $ref: "#/definitions/WebsiteLink"
+      - $ref: "#/definitions/LeadSourceLink"

--- a/spec/definitions/Subscription/UpcomingInvoice.yaml
+++ b/spec/definitions/Subscription/UpcomingInvoice.yaml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  lineItems:
+    description: Subscription line items which queue until the next renewal (or interim) invoice is issued for the subscription.
+    readOnly: true
+    allOf:
+      - $ref: "#/definitions/UpcomingInvoiceItemCollection"
+  lineItemSubtotal:
+    description: Subtotal of line items in this subscription (signed value).  If credits exceed debits, it will be a negative number.
+    readOnly: true
+    type: number
+    example: 49.95


### PR DESCRIPTION
# Details
Adds the discriminator `orderType`. However it required to split the Subscription definition in multiple pieces in order to better sort the properties.