### PR TITLE
Add ApprovalUrlLink to PaymentCard

### DIFF
--- a/spec/components/schemas/PaymentCard.yaml
+++ b/spec/components/schemas/PaymentCard.yaml
@@ -103,3 +103,4 @@ properties:
       - $ref: "#/components/schemas/SelfLink"
       - $ref: "#/components/schemas/CustomerLink"
       - $ref: "#/components/schemas/AuthTransactionLink"
+      - $ref: "#/components/schemas/ApprovalUrlLink"


### PR DESCRIPTION
- if the authorization endpoint is being consumed, and
- the gateway selected uses 3DS, then
- an approvalLink will be present in the response