### PR TITLE
Specify subscription statuses

### DIFF
--- a/spec/components/schemas/Subscription.yaml
+++ b/spec/components/schemas/Subscription.yaml
@@ -24,7 +24,7 @@ properties:
     type: string
     readOnly: true
     enum:
-      - draft
+      - pending
       - active
       - canceled
       - churned

--- a/spec/components/schemas/Subscription.yaml
+++ b/spec/components/schemas/Subscription.yaml
@@ -23,6 +23,12 @@ properties:
   status:
     type: string
     readOnly: true
+    enum:
+      - draft
+      - active
+      - canceled
+      - churned
+      - paused
   customerId:
     description: Unique id for each customer
     allOf:


### PR DESCRIPTION
At the moment outdated values are displayed: 

- `Active`
- `Will become active at a future date`
- `Active but set to cancel at next rebill date`
- `Cancelled`
- `Inactive`