### PR TITLE
Replace invoice isRefunded and isDisputed with appropriate statuses

### DIFF
--- a/spec/components/schemas/Invoice.yaml
+++ b/spec/components/schemas/Invoice.yaml
@@ -96,14 +96,8 @@ properties:
      - "paid"
      - "abandoned"
      - "voided"
-  isDisputed:
-    type: string
-    description: Whether the invoice (related transaction) has been disputed
-    readOnly: true
-  isRefunded:
-    type: string
-    description: Whether the invoice (related transaction) has been subsequently refunded
-    readOnly: true
+     - "disputed"
+     - "refunded"
   delinquentCollectionPeriod:
     type: integer
     description: Delinquent Collection Period - difference between paidTime and dueTime in days.


### PR DESCRIPTION
As I understand, an invoice can be disputed only when it's paid, and paid status cannot change, so this would be logical to make as states