### PR TITLE
Make custom field name read-only

### DIFF
--- a/spec/components/schemas/CustomField.yaml
+++ b/spec/components/schemas/CustomField.yaml
@@ -1,12 +1,12 @@
 description: A separate Custom Field schema
 type: object
 required:
-  - name
   - type
 properties:
   name:
     description: The name of the custom field
     type: string
+    readOnly: true
   type:
     description: |
       Type value    | Description


### PR DESCRIPTION
Name actually used only from pathParameters and not from the request body and there should be no way to change field name because it stands for an id and url-slug