### PR TITLE
Rename redemptionCode to id/couponId

### DIFF
--- a/spec/code_samples/PHP/coupons-redemptions/post.php
+++ b/spec/code_samples/PHP/coupons-redemptions/post.php
@@ -1,6 +1,6 @@
 $redemptionForm = new Rebilly\Entities\Coupons\Redemption();
 $redemptionForm->setCustomerId('customerId');
-$redemptionForm->setRedemptionCode('redemptionCode');
+$redemptionForm->setCouponId('id');
 
 $restrictionArray = [
     'type' => Rebilly\Entities\Coupons\Restriction::TYPE_DISCOUNTS_PER_REDEMPTION,

--- a/spec/code_samples/PHP/coupons-redemptions@{id}/get.php
+++ b/spec/code_samples/PHP/coupons-redemptions@{id}/get.php
@@ -1,1 +1,1 @@
-$couponRedemption = $client->couponsRedemptions()->load('redemptionCode');
+$couponRedemption = $client->couponsRedemptions()->load('couponId');

--- a/spec/code_samples/PHP/coupons@{id}/get.php
+++ b/spec/code_samples/PHP/coupons@{id}/get.php
@@ -1,0 +1,1 @@
+$coupon = $client->coupons()->load('id');

--- a/spec/code_samples/PHP/coupons@{id}/put.php
+++ b/spec/code_samples/PHP/coupons@{id}/put.php
@@ -21,7 +21,7 @@ $restrictionForm = new Rebilly\Entities\Coupons\Restriction([
 $couponForm->setRestrictions($restrictionForm);
 
 try {
-    $coupon = $client->coupons()->create($couponForm, 'redemptionCode');
+    $coupon = $client->coupons()->create($couponForm, 'couponId');
 } catch (UnprocessableEntityException $e) {
     echo $e->getMessage();
 }

--- a/spec/code_samples/PHP/coupons@{redemptionCode}/get.php
+++ b/spec/code_samples/PHP/coupons@{redemptionCode}/get.php
@@ -1,1 +1,0 @@
-$coupon = $client->coupons()->load('redemptionCode');

--- a/spec/components/schemas/Coupon/Coupon.yaml
+++ b/spec/components/schemas/Coupon/Coupon.yaml
@@ -4,8 +4,8 @@ required:
   - discount
   - issuedTime
 properties:
-  redemptionCode:
-    description: Coupon's redemption code
+  id:
+    description: Coupon's ID which can be used as a redemption code
     readOnly: true
     allOf:
       - $ref: "#/components/schemas/ResourceId"
@@ -32,7 +32,7 @@ properties:
     type: string
     description: |
       Your coupon description. When it is not empty this is used for invoice discount item description,
-      otherwise the item's description uses coupon's redemptionCode like 'Coupon "redemptionCode"'
+      otherwise the item's description uses coupon's couponId like 'Coupon "couponId"'
   issuedTime:
     description: Coupon's issued time (start time)
     type: string

--- a/spec/components/schemas/Coupon/CouponRedemption.yaml
+++ b/spec/components/schemas/Coupon/CouponRedemption.yaml
@@ -5,8 +5,8 @@ properties:
     readOnly: true
     allOf:
       - $ref: "#/components/schemas/ResourceId"
-  redemptionCode:
-    description: Coupon's redemption code
+  couponId:
+    description: Coupon's ID
     allOf:
       - $ref: "#/components/schemas/ResourceId"
   customerId:

--- a/spec/components/schemas/Coupon/InvoiceDiscount.yaml
+++ b/spec/components/schemas/Coupon/InvoiceDiscount.yaml
@@ -1,8 +1,8 @@
 type: object
 readOnly: true
 properties:
-  redemptionCode:
-    description: Coupon's redemption code
+  couponId:
+    description: Coupon's ID
     allOf:
       - $ref: "#/components/schemas/ResourceId"
   redemptionId:

--- a/spec/paths/coupons@{id}.yaml
+++ b/spec/paths/coupons@{id}.yaml
@@ -1,7 +1,7 @@
 parameters:
-  - name: redemptionCode
+  - name: id
     in: path
-    description: The Coupon's redemption code
+    description: The Coupon's ID
     required: true
     schema:
       type: string
@@ -10,7 +10,7 @@ get:
     - Coupons
   summary: Retrieve a coupon
   description: |
-    Retrieve a coupon with specified redemption code string
+    Retrieve a coupon with specified ID
   responses:
     200:
       description: Coupon was retrieved successfully
@@ -32,9 +32,9 @@ get:
 put:
   tags:
     - Coupons
-  summary: Create or update a coupon with predefined redemption code
+  summary: Create or update a coupon with predefined ID
   description: |
-    Create or update a coupon with predefined redemption code
+    Create or update a coupon with predefined ID
   requestBody:
     $ref: "#/components/requestBodies/Coupon"
   responses:

--- a/spec/paths/coupons@{id}@expiration.yaml
+++ b/spec/paths/coupons@{id}@expiration.yaml
@@ -1,7 +1,7 @@
 parameters:
-  - name: redemptionCode
+  - name: id
     in: path
-    description: The coupon's redemption code
+    description: The coupon's ID
     required: true
     schema:
       type: string
@@ -10,7 +10,7 @@ post:
     - Coupons
   summary: Set a coupon's expiration time.
   description: |
-    Set a coupon's expiry time with the specified redemption code.
+    Set a coupon's expiry time with the specified ID.
     The expiredTime of a coupon must be greater than its issuedTime.
     This cannot be performed on expired coupons.
   requestBody:


### PR DESCRIPTION
Coupon is the only resource which has its identifier named not as `id` but `redemptionCode`. At the same time there are redemptions. This whole situation seems confusing to me.