### PR TITLE
Add missing coupon status value

### DIFF
--- a/spec/components/schemas/Coupon/Coupon.yaml
+++ b/spec/components/schemas/Coupon/Coupon.yaml
@@ -26,6 +26,7 @@ properties:
     description: If coupon enabled
     readOnly: true
     enum:
+      - draft
       - issued
       - expired
   description:


### PR DESCRIPTION
The `draft` status is returned by the API but it is missing in the spec.