### PR TITLE
Add an ability to make subscription pending or active

### DIFF
--- a/spec/components/schemas/Subscription.yaml
+++ b/spec/components/schemas/Subscription.yaml
@@ -35,7 +35,7 @@ properties:
       - paused
   autoActivation:
     type: boolean
-    descrition: |
+    description: |
       If `true` then the subscription becomes active when initial invoice is paid.
       If `false` the subscription will remain in status "pending" until status is set `active`.
     default: true

--- a/spec/components/schemas/Subscription.yaml
+++ b/spec/components/schemas/Subscription.yaml
@@ -24,9 +24,8 @@ properties:
     type: string
     description: |
       The status of the subscription service. A subscription starts
-      in the `pending` status, and will become `active` when the 
-      service period begins.
-    readOnly: true
+      in the `pending` status, and will become `active` when the
+      service period begins. Status `active` can be assigned forcefully.
     enum:
       - pending
       - active
@@ -34,6 +33,10 @@ properties:
       - churned
       - suspended
       - paused
+  forcePending:
+    type: boolean
+    descrition: If `true` then the subscription will remain in status "pending" until it's updated with `false`.
+    default: false
   billingStatus:
     description: |
       The billing status of the most recent invoice.  It may

--- a/spec/components/schemas/Subscription.yaml
+++ b/spec/components/schemas/Subscription.yaml
@@ -23,9 +23,9 @@ properties:
   status:
     type: string
     description: |
-      The status of the subscription service. A subscription starts
-      in the `pending` status, and will become `active` when the
-      service period begins. Status `active` can be assigned forcefully.
+      The status of the subscription. A subscription starts in the `pending` status,
+      and becomes `active` either when the initial invoice is paid (when autoActivation is on)
+      or when status `active` is assigned by user.
     enum:
       - pending
       - active
@@ -33,10 +33,12 @@ properties:
       - churned
       - suspended
       - paused
-  forcePending:
+  autoActivation:
     type: boolean
-    descrition: If `true` then the subscription will remain in status "pending" until it's updated with `false`.
-    default: false
+    descrition: |
+      If `true` then the subscription becomes active when initial invoice is paid.
+      If `false` the subscription will remain in status "pending" until status is set `active`.
+    default: true
   billingStatus:
     description: |
       The billing status of the most recent invoice.  It may


### PR DESCRIPTION
Alternative approach suggested by @slavcodev from https://github.com/Rebilly/RebillyAPI/pull/632