### PR TITLE
Add searched field to Search response

### DIFF
--- a/spec/components/schemas/Search.yaml
+++ b/spec/components/schemas/Search.yaml
@@ -28,3 +28,9 @@ properties:
     items:
       allOf:
         - $ref: "#/components/schemas/Transaction"
+  searched:
+    description: Names of searched resources, even if they returned nothing
+    readOnly: true
+    type: array
+    items:
+      type: string


### PR DESCRIPTION
Add the `searched` field to Search response. It lists resources that were searched.