### PR TITLE
Fix Customer Auth passwordless typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,3 @@ node_modules
 
 # npm
 package-lock.json
-
-# JetBrains IDEs
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ node_modules
 
 # npm
 package-lock.json
+
+# JetBrains IDEs
+.idea

--- a/spec/components/schemas/CustomerAuthentication/AuthenticationToken.yaml
+++ b/spec/components/schemas/CustomerAuthentication/AuthenticationToken.yaml
@@ -11,7 +11,7 @@ properties:
     type: string
     enum:
       - "password"
-      - "password-less"
+      - "passwordless"
     writeOnly: true
     default: "password"
   credentialId:


### PR DESCRIPTION
Actually should be `passwordless` and not `password-less`. It was discussed earlier on the backend side