### PR TITLE
Add missing customFields to subscription definition

### DIFF
--- a/spec/components/schemas/Subscription.yaml
+++ b/spec/components/schemas/Subscription.yaml
@@ -148,6 +148,8 @@ properties:
     nullable: true
     example: PO123456
     type: string
+  customFields:
+    $ref: "#/components/schemas/ResourceCustomFields"
   _links:
     type: array
     description: The links related to resource


### PR DESCRIPTION
After a recent change to add a discriminator to subscriptions it seems that `customFields` was lost from the entity. This simply adds it back.