### PR TITLE
Add "partially-refunded" Invoice status and related timeline events

### DIFF
--- a/spec/components/schemas/Invoices/Invoice.yaml
+++ b/spec/components/schemas/Invoices/Invoice.yaml
@@ -160,6 +160,7 @@ properties:
      - "delinquent"
      - "abandoned"
      - "voided"
+     - "partially-refunded"
      - "refunded"
      - "disputed"
   delinquentCollectionPeriod:

--- a/spec/components/schemas/Timelines/CustomerTimeline.yaml
+++ b/spec/components/schemas/Timelines/CustomerTimeline.yaml
@@ -36,6 +36,7 @@ properties:
       - invoice-partially-paid
       - invoice-disputed
       - invoice-refunded
+      - invoice-partially-refunded
       - order-created
       - order-renewed
       - order-activated

--- a/spec/components/schemas/Timelines/InvoiceTimeline.yaml
+++ b/spec/components/schemas/Timelines/InvoiceTimeline.yaml
@@ -20,6 +20,7 @@ properties:
       - invoice-partially-paid
       - invoice-disputed
       - invoice-refunded
+      - invoice-partially-refunded
       - invoice-renewal-payment-declined
       - email-message-sent
   triggeredBy:

--- a/spec/components/schemas/Timelines/OrderTimeline.yaml
+++ b/spec/components/schemas/Timelines/OrderTimeline.yaml
@@ -37,6 +37,7 @@ properties:
       - invoice-partially-paid
       - invoice-disputed
       - invoice-refunded
+      - invoice-partially-refunded
       - invoice-renewal-payment-declined
   triggeredBy:
     description: Shows who or what triggered the Timeline message


### PR DESCRIPTION
This PR:
- Adds `partially-refunded` status to Invoice schema
- Adds `invoice-partially-refunded` event to Customer, Invoice and Order Timeline schemas