### PR TITLE
Introduce a CurrencyCode data type

### DIFF
--- a/spec/components/schemas/Coupon/CouponRestrictions/minimum-order-amount.yaml
+++ b/spec/components/schemas/Coupon/CouponRestrictions/minimum-order-amount.yaml
@@ -11,5 +11,5 @@ allOf:
         type: integer
         description: Minimum order quantity
       currency:
-        type: string
-        description: Minimum order currency
+        allOf:
+          - $ref: "#/components/schemas/CurrencyCode"

--- a/spec/components/schemas/Coupon/Discounts/fixed.yaml
+++ b/spec/components/schemas/Coupon/Discounts/fixed.yaml
@@ -15,5 +15,5 @@ allOf:
         minimum: 0
         exclusiveMinimum: true
       currency:
-        description: Discount currency
-        type: string
+        allOf:
+          - $ref: "#/components/schemas/CurrencyCode"

--- a/spec/components/schemas/CurrencyCode.yaml
+++ b/spec/components/schemas/CurrencyCode.yaml
@@ -1,0 +1,5 @@
+type: string
+description: ISO 4217 alphabetic currency code
+minLength: 3
+maxLength: 3
+example: "USD"

--- a/spec/components/schemas/CustomerAverageValue.yaml
+++ b/spec/components/schemas/CustomerAverageValue.yaml
@@ -3,7 +3,8 @@ readOnly: true
 properties:
   currency:
     description: Merchant's reporting currency
-    type: string
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   amount:
     description: Average approved payment amount in Merchant's reporting currency
     type: number

--- a/spec/components/schemas/CustomerLifetimeRevenue.yaml
+++ b/spec/components/schemas/CustomerLifetimeRevenue.yaml
@@ -3,7 +3,8 @@ readOnly: true
 properties:
   currency:
     description: Merchant's reporting currency
-    type: string
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   amount:
     description: Revenue amount in Merchant's reporting currency
     type: number

--- a/spec/components/schemas/Dispute.yaml
+++ b/spec/components/schemas/Dispute.yaml
@@ -20,8 +20,8 @@ properties:
     description: The dispute's transaction ID
     type: string
   currency:
-    description: The dispute currency ISO Alpha code
-    type: string
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   amount:
     description: The dispute amount
     type: number

--- a/spec/components/schemas/Invoices/Invoice.yaml
+++ b/spec/components/schemas/Invoices/Invoice.yaml
@@ -32,8 +32,8 @@ properties:
     allOf:
       - $ref: "#/components/schemas/ResourceId"
   currency:
-    description: The currency three letter code
-    type: string
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   amount:
     description: The Invoice's amount
     type: number

--- a/spec/components/schemas/LeadSourceData.yaml
+++ b/spec/components/schemas/LeadSourceData.yaml
@@ -31,8 +31,8 @@ properties:
     description: Lead Source's path uri (eg www.example.com/some/landing/path)
     type: string
   currency:
-    description: Currency (three letter ISO 4217 alpha code) (eg USD, EUR)
-    type: string
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   amount:
     description: The amount that the lead cost
     type: number

--- a/spec/components/schemas/Payment.yaml
+++ b/spec/components/schemas/Payment.yaml
@@ -19,8 +19,8 @@ properties:
     allOf:
       - $ref: "#/components/schemas/ResourceId"
   currency:
-    description: The payment currency ISO Alpha code
-    type: string
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   amount:
     description: The payment amount
     type: number

--- a/spec/components/schemas/Plans/Plan.yaml
+++ b/spec/components/schemas/Plans/Plan.yaml
@@ -29,8 +29,8 @@ properties:
       color: red
       size: xxl
   currency:
-    description: Currency (three letter ISO 4217 code)
-    type: string
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   currencySign:
     description: Currency sign
     readOnly: true

--- a/spec/components/schemas/PriceBasedShippingRate.yaml
+++ b/spec/components/schemas/PriceBasedShippingRate.yaml
@@ -22,8 +22,8 @@ properties:
     type: number
     format: double
   currency:
-    description: Currency (three letter ISO 4217 code)
-    type: string
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   _links:
     type: array
     description: The links related to resource

--- a/spec/components/schemas/Subscription/UpcomingInvoiceItem.yaml
+++ b/spec/components/schemas/Subscription/UpcomingInvoiceItem.yaml
@@ -21,9 +21,8 @@ properties:
     format: double
     example: 49.95
   unitPriceCurrency:
-    description: Currency ISO code
-    type: string
-    example: USD
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   quantity:
     description: Quantity of line item
     type: integer

--- a/spec/components/schemas/ThreeDSecure.yaml
+++ b/spec/components/schemas/ThreeDSecure.yaml
@@ -68,8 +68,8 @@ properties:
     type: number
     format: double
   currency:
-    description: The currency three letter code
-    type: string
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   createdTime:
     description: The 3D Secure entry created time
     allOf:

--- a/spec/components/schemas/Transactions/Transaction.yaml
+++ b/spec/components/schemas/Transactions/Transaction.yaml
@@ -50,27 +50,27 @@ properties:
     format: double
     readOnly: true
   currency:
-    description: The transactions's currency
-    type: string
     readOnly: true
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   purchaseAmount:
     description: The transactions's purchase amount
     type: number
     format: double
     readOnly: true
   purchaseCurrency:
-    description: The transactions's purchase currency
-    type: string
     readOnly: true
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   requestAmount:
     description: The transactions's amount received in the payment request
     type: number
     format: double
     readOnly: true
   requestCurrency:
-    description: The transactions's currency received in the payment request
-    type: string
     readOnly: true
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   parentTransactionId:
     description: The transactions's parent ID
     allOf:
@@ -249,7 +249,8 @@ properties:
             type: number
             format: double
           currency:
-            type: string
+            allOf:
+              - $ref: "#/components/schemas/CurrencyCode"
       quote:
         type: object
         description: Suggested amount and currency to convert to
@@ -258,7 +259,8 @@ properties:
             type: number
             format: double
           currency:
-            type: string
+            allOf:
+              - $ref: "#/components/schemas/CurrencyCode"
       usdMarkup:
         description: The amount of markup translated to USD
         type: number
@@ -287,7 +289,8 @@ properties:
             type: number
             format: double
           currency:
-            type: string
+            allOf:
+              - $ref: "#/components/schemas/CurrencyCode"
       bump:
         type: object
         description: Bump amount and currency
@@ -296,7 +299,8 @@ properties:
             type: number
             format: double
           currency:
-            type: string
+            allOf:
+              - $ref: "#/components/schemas/CurrencyCode"
       bonus:
         type: object
         description: Bonus amount and currency
@@ -305,7 +309,8 @@ properties:
             type: number
             format: double
           currency:
-            type: string
+            allOf:
+              - $ref: "#/components/schemas/CurrencyCode"
       usdOrder:
         description: The amount of initial amount translated to USD
         type: number

--- a/spec/components/schemas/Transactions/TransactionRequest.yaml
+++ b/spec/components/schemas/Transactions/TransactionRequest.yaml
@@ -20,9 +20,8 @@ properties:
     allOf:
       - $ref: "#/components/schemas/ResourceId"
   currency:
-    description: The payment currency ISO-4217 Alpha 3 Code
-    type: string
-    example: USD
+    allOf:
+      - $ref: "#/components/schemas/CurrencyCode"
   type:
     description: |
       The type of transaction requested.

--- a/spec/paths/payment-cards@{id}@authorization.yaml
+++ b/spec/paths/payment-cards@{id}@authorization.yaml
@@ -20,8 +20,8 @@ post:
               description: The Website ID
               type: string
             currency:
-              description: Currency (three letter code)
-              type: string
+              allOf:
+                - $ref: "#/components/schemas/CurrencyCode"
             gatewayAccountId:
               description: The Gateway account ID
               type: string

--- a/spec/paths/paypal-accounts@{id}@activation.yaml
+++ b/spec/paths/paypal-accounts@{id}@activation.yaml
@@ -20,8 +20,8 @@ post:
               description: The Website ID
               type: string
             currency:
-              description: Currency (three letter code)
-              type: string
+              allOf:
+                - $ref: "#/components/schemas/CurrencyCode"
             amount:
               description: The amount to authorize
               type: number


### PR DESCRIPTION
As per suggestion from https://github.com/Rebilly/RebillyAPI/pull/734#discussion_r318658263, this PR: 

* Introduces a CurrencyCode data type
* Integrates the newly introduced type with all existing schemas listing a currency