### PR TITLE
Remove websiteId from payment token

### DIFF
--- a/spec/components/schemas/PaymentTokens/PaymentToken.yaml
+++ b/spec/components/schemas/PaymentTokens/PaymentToken.yaml
@@ -9,10 +9,6 @@ properties:
     readOnly: true
     allOf:
       - $ref: "#/components/schemas/ResourceId"
-  websiteId:
-    description: The website's ID
-    allOf:
-      - $ref: "#/components/schemas/ResourceId"
   isUsed:
     description: Whether the token was already used
     type: boolean


### PR DESCRIPTION
It was added by mistake in #703, tokens don't have websiteId