### PR TITLE
Remove startTime for one-time orders

### DIFF
--- a/spec/components/schemas/Subscription.yaml
+++ b/spec/components/schemas/Subscription.yaml
@@ -124,13 +124,6 @@ properties:
     description: Risk metadata. If null, the value would coalesce to the risk metadata captured when creating the payment token.
     allOf:
       - $ref: "#/components/schemas/RiskMetadata"
-  startTime:
-    description: Subscription start time.  When the value is sent as null, it will use the current time.
-      This value can't be in past more than one service period.
-    nullable: true
-    example: null
-    type: string
-    format: date-time
   activationTime:
     description: Subscription activation time
     allOf:

--- a/spec/components/schemas/Subscription/OrderTypes/subscription-order.yaml
+++ b/spec/components/schemas/Subscription/OrderTypes/subscription-order.yaml
@@ -29,6 +29,13 @@ allOf:
             description: The time the trial should end
             type: string
             format: date-time
+      startTime:
+        description: Subscription start time.  When the value is sent as null, it will use the current time.
+          This value can't be in past more than one service period.
+        nullable: true
+        example: null
+        type: string
+        format: date-time
       endTime:
         description: Subscription end time
         allOf:


### PR DESCRIPTION
`startTime` is only makes sense for `subscription` orders, not for `one-time` ones