### PR TITLE
Fix the division by subscription and 1-time orders

### DIFF
--- a/spec/components/schemas/Subscription.yaml
+++ b/spec/components/schemas/Subscription.yaml
@@ -2,6 +2,7 @@ type: object
 discriminator:
   propertyName: orderType
 required:
+  - orderType
   - customerId
   - websiteId
   - items
@@ -19,21 +20,6 @@ properties:
       - "subscription-order"
       - "one-time-order"
     default: "subscription-order"
-  status:
-    type: string
-    description: |
-      The status of the subscription service. A subscription starts
-      in the `pending` status, and will become `active` when the
-      service period begins.
-    readOnly: true
-    enum:
-      - pending
-      - active
-      - canceled
-      - churned
-      - suspended
-      - paused
-      - abandoned
   billingStatus:
     description: |
       The billing status of the most recent invoice.  It may
@@ -83,27 +69,6 @@ properties:
         quantity:
           description: Number of units of the product on the given plan
           type: integer
-  invoiceTimeShift:
-    description: |
-      You can shift issue time and due time of invoices for this subscription.
-      This setting overrides plan settings. To use plan settings, set `null`.
-      To use multiple plans in one subscription they all must have the same billing period,
-      this property allows to subscribe to different plans.
-    nullable: true
-    example: null
-    allOf:
-      - $ref: "#/components/schemas/InvoiceTimeShift"
-  recurringInterval:
-    type: object
-    description: |
-      The recurring interval to override plan settings. To use plan settings, set `null`.
-      To use multiple plans in one subscription they all must have the same recurring period length,
-      this property allows to subscribe to different plans.
-    nullable: true
-    example: null
-    properties:
-      periodAnchorInstruction:
-        $ref: "#/components/schemas/ServicePeriodAnchorInstruction"
   deliveryAddress:
     description: Delivery address
     nullable: true
@@ -114,10 +79,6 @@ properties:
     nullable: true
     allOf:
       - $ref: "#/components/schemas/ContactObject"
-  autopay:
-    description: Autopay determines if a payment attempt will be automatic
-    type: boolean
-    default: true
   riskMetadata:
     nullable: true
     example: null
@@ -155,32 +116,12 @@ properties:
     nullable: true
     example: PO123456
     type: string
-  renewalReminderTime:
-    description: Time renewal reminder event will be triggered
-    nullable: true
-    allOf:
-        - $ref: "#/components/schemas/ServerTimestamp"
-  renewalReminderNumber:
-    description: Number of renewal reminder events triggered
-    type: integer
-    readOnly: true
-  trialReminderTime:
-    description: Time renewal reminder event will be triggered
-    nullable: true
-    allOf:
-      - $ref: "#/components/schemas/ServerTimestamp"
-  trialReminderNumber:
-    description: Number of renewal reminder events triggered
-    type: integer
-    readOnly: true
   revision:
     description: |
       The number of times the subscription data has been modified.
       The revision is useful when analyzing webhook data to determine if the change takes precedence over the current representation.
     type: integer
     readOnly: true
-  customFields:
-    $ref: "#/components/schemas/ResourceCustomFields"
   _links:
     type: array
     description: The links related to resource

--- a/spec/components/schemas/Subscription/OrderTypes/one-time-order.yaml
+++ b/spec/components/schemas/Subscription/OrderTypes/one-time-order.yaml
@@ -8,7 +8,5 @@ allOf:
         enum:
           - pending
           - paid
-          - canceled
-  - $ref: "#/components/schemas/UpcomingInvoice"
+          - abandoned
   - $ref: "#/components/schemas/SubscriptionMetadata"
-  - $ref: "#/components/schemas/SubscriptionCancellationState"

--- a/spec/components/schemas/Subscription/OrderTypes/subscription-order.yaml
+++ b/spec/components/schemas/Subscription/OrderTypes/subscription-order.yaml
@@ -2,16 +2,20 @@ allOf:
   - $ref: "#/components/schemas/Subscription"
   - properties:
       status:
-        description: Subscription status is deprecated and the values will change to `active`, `canceled`.
+        description: |
+          The status of the subscription service. A subscription starts
+          in the `pending` status, and will become `active` when the
+          service period begins.
         type: string
         readOnly: true
         enum:
-          - Active
-          - Will become active at a future date
-          - Active but set to cancel at next rebill date
-          - Cancelled
-          - Inactive
-          - Suspended
+          - pending
+          - active
+          - canceled
+          - churned
+          - suspended
+          - paused
+          - abandoned
       inTrial:
         description: True if the subscription is currently in a trial period
         type: boolean
@@ -29,6 +33,31 @@ allOf:
             description: The time the trial should end
             type: string
             format: date-time
+      invoiceTimeShift:
+        description: |
+          You can shift issue time and due time of invoices for this subscription.
+          This setting overrides plan settings. To use plan settings, set `null`.
+          To use multiple plans in one subscription they all must have the same billing period,
+          this property allows to subscribe to different plans.
+        nullable: true
+        example: null
+        allOf:
+          - $ref: "#/components/schemas/InvoiceTimeShift"
+      recurringInterval:
+        type: object
+        description: |
+          The recurring interval to override plan settings. To use plan settings, set `null`.
+          To use multiple plans in one subscription they all must have the same recurring period length,
+          this property allows to subscribe to different plans.
+        nullable: true
+        example: null
+        properties:
+          periodAnchorInstruction:
+            $ref: "#/components/schemas/ServicePeriodAnchorInstruction"
+      autopay:
+        description: Autopay determines if a payment attempt will be automatic
+        type: boolean
+        default: true
       startTime:
         description: Subscription start time.  When the value is sent as null, it will use the current time.
           This value can't be in past more than one service period.
@@ -46,6 +75,24 @@ allOf:
         format: date-time
       rebillNumber:
         description: The current period number
+        type: integer
+        readOnly: true
+      renewalReminderTime:
+        description: Time renewal reminder event will be triggered
+        nullable: true
+        allOf:
+          - $ref: "#/components/schemas/ServerTimestamp"
+      renewalReminderNumber:
+        description: Number of renewal reminder events triggered
+        type: integer
+        readOnly: true
+      trialReminderTime:
+        description: Time renewal reminder event will be triggered
+        nullable: true
+        allOf:
+          - $ref: "#/components/schemas/ServerTimestamp"
+      trialReminderNumber:
+        description: Number of renewal reminder events triggered
         type: integer
         readOnly: true
   - $ref: "#/components/schemas/UpcomingInvoice"


### PR DESCRIPTION
- 1-time order has no cancellation and interim from changing.
- Only subscription can have invoice/recurring time settings.
- Autopay makes sense only in a subscription.
- Reminders make sense only in a subscription.
- They can have different statuses.