### PR TITLE
Move subscription link from invoice item to invoice

### DIFF
--- a/spec/components/schemas/Invoices/Invoice.yaml
+++ b/spec/components/schemas/Invoices/Invoice.yaml
@@ -242,4 +242,3 @@ properties:
         - $ref: "#/components/schemas/WebsiteEmbed"
         - $ref: "#/components/schemas/OrganizationEmbed"
         - $ref: "#/components/schemas/LeadSourceEmbed"
-        - $ref: "#/components/schemas/SubscriptionEmbed"

--- a/spec/components/schemas/Invoices/Invoice.yaml
+++ b/spec/components/schemas/Invoices/Invoice.yaml
@@ -230,6 +230,7 @@ properties:
       - $ref: "#/components/schemas/LeadSourceLink"
       - $ref: "#/components/schemas/TransactionAllocationsLink"
       - $ref: "#/components/schemas/RecalculateInvoiceLink"
+      - $ref: "#/components/schemas/SubscriptionLink"
   _embedded:
     type: array
     description: Any embedded objects available that are requested by the `expand` querystring parameter.
@@ -241,3 +242,4 @@ properties:
         - $ref: "#/components/schemas/WebsiteEmbed"
         - $ref: "#/components/schemas/OrganizationEmbed"
         - $ref: "#/components/schemas/LeadSourceEmbed"
+        - $ref: "#/components/schemas/SubscriptionEmbed"

--- a/spec/components/schemas/Invoices/InvoiceItem.yaml
+++ b/spec/components/schemas/Invoices/InvoiceItem.yaml
@@ -65,7 +65,6 @@ properties:
     items:
       anyOf:
         - $ref: "#/components/schemas/SelfLink"
-        - $ref: "#/components/schemas/SubscriptionLink"
         - $ref: "#/components/schemas/ProductLink"
   _embedded:
     type: array

--- a/spec/components/schemas/Links/SubscriptionLink.yaml
+++ b/spec/components/schemas/Links/SubscriptionLink.yaml
@@ -6,6 +6,6 @@ properties:
     description: The link type
     type: string
     enum:
-      - order
+      - subscription
 required:
   - rel

--- a/spec/components/schemas/Links/SubscriptionLink.yaml
+++ b/spec/components/schemas/Links/SubscriptionLink.yaml
@@ -6,6 +6,6 @@ properties:
     description: The link type
     type: string
     enum:
-      - subscription
+      - order
 required:
   - rel


### PR DESCRIPTION
All Invoice Items can belong only to 1 subscription as the invoice.